### PR TITLE
Feature/auth login and guard

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,20 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "flutter_run_analyze",
+			"type": "shell",
+			"command": "flutter --version; dart --version; flutter pub get; flutter analyze"
+		},
+		{
+			"label": "flutter_test",
+			"type": "shell",
+			"command": "flutter test"
+		},
+		{
+			"label": "flutter_test_retry",
+			"type": "shell",
+			"command": "flutter test"
+		}
+	]
+}

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -1,15 +1,25 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../features/dashboard/presentation/dashboard_page.dart';
+import '../features/course/presentation/course_page.dart';
 
-/// Provides [GoRouter] configuration without authentication.
-final routerProvider = Provider<GoRouter>((ref) {
+/// GoRouter provider (no auth guards yet).
+final goRouterProvider = Provider<GoRouter>((ref) {
   return GoRouter(
     initialLocation: '/',
     routes: [
+      GoRoute(path: '/', builder: (context, state) => const HomePage()),
       GoRoute(
-        path: '/',
-        builder: (context, state) => const HomePage(),
+        path: '/dashboard',
+        builder: (context, state) => const DashboardPage(),
+      ),
+      GoRoute(
+        path: '/course/:id',
+        builder: (context, state) {
+          final id = state.pathParameters['id']!;
+          return CoursePage(courseId: id);
+        },
       ),
     ],
   );
@@ -18,11 +28,10 @@ final routerProvider = Provider<GoRouter>((ref) {
 /// Placeholder home page for routing demonstration.
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
-
   @override
   Widget build(BuildContext context) {
     return const Scaffold(
-      body: Center(child: Text('Home')), // TODO: Replace with actual home UI
+      body: Center(child: Text('Home')), // TODO(l10n): localize
     );
   }
 }

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -1,1 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
+/// Provides [GoRouter] configuration without authentication.
+final routerProvider = Provider<GoRouter>((ref) {
+  return GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => const HomePage(),
+      ),
+    ],
+  );
+});
+
+/// Placeholder home page for routing demonstration.
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(child: Text('Home')), // TODO: Replace with actual home UI
+    );
+  }
+}

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -1,15 +1,29 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import '../features/dashboard/presentation/dashboard_page.dart';
-import '../features/course/presentation/course_page.dart';
 
-/// GoRouter provider (no auth guards yet).
-final goRouterProvider = Provider<GoRouter>((ref) {
-  return GoRouter(
-    initialLocation: '/',
+import '../features/auth/controller/auth_controller.dart';
+import '../features/auth/presentation/login_page.dart';
+import '../features/course/presentation/course_page.dart';
+import '../features/dashboard/presentation/dashboard_page.dart';
+
+/// GoRouter configured with Riverpod-based redirect logic and a login route.
+final routerProvider = Provider<GoRouter>((ref) {
+  String? redirectLogic(BuildContext context, GoRouterState state) {
+    final auth = ref.read(authControllerProvider);
+    final loggedIn = auth.userId != null;
+    final loggingIn = state.matchedLocation == '/login';
+
+    if (!loggedIn && !loggingIn) return '/login';
+    if (loggedIn && loggingIn) return '/dashboard';
+    return null;
+  }
+
+  final router = GoRouter(
+    initialLocation: '/dashboard',
+    redirect: redirectLogic,
     routes: [
-      GoRoute(path: '/', builder: (context, state) => const HomePage()),
+      GoRoute(path: '/login', builder: (context, state) => const LoginPage()),
       GoRoute(
         path: '/dashboard',
         builder: (context, state) => const DashboardPage(),
@@ -23,15 +37,9 @@ final goRouterProvider = Provider<GoRouter>((ref) {
       ),
     ],
   );
-});
 
-/// Placeholder home page for routing demonstration.
-class HomePage extends StatelessWidget {
-  const HomePage({super.key});
-  @override
-  Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(child: Text('Home')), // TODO(l10n): localize
-    );
-  }
-}
+  // Refresh router when auth state changes so redirect re-evaluates.
+  ref.listen(authControllerProvider, (_, __) => router.refresh());
+
+  return router;
+});

--- a/lib/features/auth/controller/auth_controller.dart
+++ b/lib/features/auth/controller/auth_controller.dart
@@ -1,0 +1,69 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../domain/auth_repository.dart';
+import '../data/local_auth_repository.dart';
+
+class AuthState {
+  final bool isLoading;
+  final String? userId;
+  final String? error;
+
+  const AuthState({this.isLoading = false, this.userId, this.error});
+
+  AuthState copyWith({bool? isLoading, String? userId, String? error}) {
+    return AuthState(
+      isLoading: isLoading ?? this.isLoading,
+      userId: userId ?? this.userId,
+      error: error,
+    );
+  }
+}
+
+class AuthController extends StateNotifier<AuthState> {
+  AuthController(this._repo) : super(const AuthState()) {
+    _sub = _repo.authStateChanges().listen((uid) {
+      state = state.copyWith(userId: uid, isLoading: false, error: null);
+    });
+  }
+
+  final AuthRepository _repo;
+  StreamSubscription<String?>? _sub;
+
+  Future<void> signIn(String email, String password) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final uid = await _repo.signIn(email: email, password: password);
+      state = state.copyWith(userId: uid, isLoading: false, error: null);
+    } catch (e) {
+      state = state.copyWith(isLoading: false, error: e.toString());
+    }
+  }
+
+  Future<void> signOut() async {
+    state = state.copyWith(isLoading: true, error: null);
+    await _repo.signOut();
+    state = state.copyWith(isLoading: false);
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+}
+
+// Providers
+final authRepositoryProvider = Provider<AuthRepository>((ref) {
+  final repo = LocalAuthRepository();
+  ref.onDispose(() => repo.dispose());
+  return repo;
+});
+
+final authControllerProvider = StateNotifierProvider<AuthController, AuthState>(
+  (ref) {
+    final repo = ref.watch(authRepositoryProvider);
+    return AuthController(repo);
+  },
+);

--- a/lib/features/auth/data/local_auth_repository.dart
+++ b/lib/features/auth/data/local_auth_repository.dart
@@ -1,0 +1,47 @@
+import 'dart:async';
+
+import '../../auth/domain/auth_repository.dart';
+
+/// A local in-memory implementation of [AuthRepository].
+class LocalAuthRepository implements AuthRepository {
+  final _controller = StreamController<String?>.broadcast();
+  String? _currentUserId;
+
+  @override
+  String? get currentUserId => _currentUserId;
+
+  @override
+  Future<String> signIn({
+    required String email,
+    required String password,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 400));
+
+    if (!email.contains('@') || password.length < 6) {
+      throw Exception('Invalid credentials');
+    }
+
+    // Generate a simple user id from email.
+    _currentUserId = email;
+    _controller.add(_currentUserId);
+    return _currentUserId!;
+  }
+
+  @override
+  Future<void> signOut() async {
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    _currentUserId = null;
+    _controller.add(_currentUserId);
+  }
+
+  @override
+  Stream<String?> authStateChanges() async* {
+    // Emit initial state then subsequent changes.
+    yield _currentUserId;
+    yield* _controller.stream;
+  }
+
+  void dispose() {
+    _controller.close();
+  }
+}

--- a/lib/features/auth/domain/auth_repository.dart
+++ b/lib/features/auth/domain/auth_repository.dart
@@ -1,0 +1,16 @@
+import 'dart:async';
+
+/// Abstraction for authentication operations.
+abstract class AuthRepository {
+  /// The current user's id, or null if signed out.
+  String? get currentUserId;
+
+  /// Attempts to sign in. Returns the user id on success.
+  Future<String> signIn({required String email, required String password});
+
+  /// Signs out the current user.
+  Future<void> signOut();
+
+  /// Emits the current user id whenever it changes.
+  Stream<String?> authStateChanges();
+}

--- a/lib/features/auth/presentation/login_page.dart
+++ b/lib/features/auth/presentation/login_page.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../auth/controller/auth_controller.dart';
+
+class LoginPage extends ConsumerStatefulWidget {
+  const LoginPage({super.key});
+
+  @override
+  ConsumerState<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends ConsumerState<LoginPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailCtrl = TextEditingController();
+  final _pwCtrl = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailCtrl.dispose();
+    _pwCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(authControllerProvider);
+
+    ref.listen(authControllerProvider, (prev, next) {
+      final err = next.error;
+      if (err != null && err.isNotEmpty) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(err)));
+      }
+    });
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 420),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Form(
+              key: _formKey,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextFormField(
+                    controller: _emailCtrl,
+                    decoration: const InputDecoration(
+                      labelText: 'Email',
+                      border: OutlineInputBorder(),
+                    ),
+                    keyboardType: TextInputType.emailAddress,
+                    validator: (v) {
+                      if (v == null || v.trim().isEmpty) return 'Enter email';
+                      if (!v.contains('@')) return 'Invalid email';
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: _pwCtrl,
+                    decoration: const InputDecoration(
+                      labelText: 'Password',
+                      border: OutlineInputBorder(),
+                    ),
+                    obscureText: true,
+                    validator: (v) {
+                      if (v == null || v.isEmpty) return 'Enter password';
+                      if (v.length < 6) return 'Min 6 characters';
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: 16),
+                  SizedBox(
+                    width: double.infinity,
+                    child: FilledButton(
+                      onPressed: state.isLoading
+                          ? null
+                          : () async {
+                              if (!_formKey.currentState!.validate()) return;
+                              await ref
+                                  .read(authControllerProvider.notifier)
+                                  .signIn(_emailCtrl.text.trim(), _pwCtrl.text);
+                            },
+                      child: state.isLoading
+                          ? const SizedBox(
+                              height: 20,
+                              width: 20,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Text('Sign in'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,176 +1,23 @@
 import 'package:flutter/material.dart';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
-// Simple auth state provider
-final authProvider = StateProvider<bool>((ref) => false);
-
-GoRouterRedirect authGuard(Ref ref) {
-  return (context, state) {
-    final isLoggedIn = ref.read(authProvider);
-
-    if (!isLoggedIn && state.matchedLocation != '/') {
-      return '/';
-    }
-    return null;
-  };
-}
-
-// GoRouter setup with Riverpod
-final goRouterProvider = Provider<GoRouter>((ref) {
-  final router = GoRouter(
-    initialLocation: '/',
-    redirect: authGuard(ref),
-    routes: [
-      GoRoute(
-        path: '/',
-        builder: (context, state) =>
-            const MyHomePage(title: 'Flutter Demo Home Page'),
-      ),
-      GoRoute(
-        path: '/dashboard',
-        builder: (context, state) => const DashboardPage(),
-      ),
-      GoRoute(
-        path: '/course/:id',
-        builder: (context, state) {
-          final id = state.pathParameters['id']!;
-          return CoursePage(courseId: id);
-        },
-      ),
-    ],
-  );
-
-  ref.listen<bool>(authProvider, (_, __) => router.refresh());
-
-  return router;
-});
-
-// Dummy pages for demonstration
-class DashboardPage extends StatelessWidget {
-  const DashboardPage({super.key});
-  @override
-  Widget build(BuildContext context) => Scaffold(
-    appBar: AppBar(title: const Text('Dashboard')),
-    body: const Center(
-      child: Text('ここがダッシュボード画面です', style: TextStyle(fontSize: 20)),
-    ),
-  );
-}
-
-class CoursePage extends StatelessWidget {
-  final String courseId;
-  const CoursePage({super.key, required this.courseId});
-  @override
-  Widget build(BuildContext context) => Scaffold(
-    appBar: AppBar(title: Text('Course $courseId')),
-    body: Center(
-      child: Text('Course ID: $courseId', style: TextStyle(fontSize: 20)),
-    ),
-  );
-}
+import 'app/router.dart';
 
 // Wrap MaterialApp with ProviderScope & use GoRouter
 class MyApp extends ConsumerWidget {
   const MyApp({super.key});
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final router = ref.watch(goRouterProvider);
+    final router = ref.watch(routerProvider);
     return MaterialApp.router(
       routerConfig: router,
       title: 'Flutter Demo',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        useMaterial3: true,
       ),
     );
   }
 }
 
 void main() => runApp(const ProviderScope(child: MyApp()));
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
-    );
-  }
-}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,26 +5,18 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lms_app/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('App boots and shows Login page for unauthenticated user', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const ProviderScope(child: MyApp()));
+    await tester.pumpAndSettle();
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Expect to be on the Login screen by default (guard redirects unauthenticated users).
+    expect(find.text('Login'), findsOneWidget);
   });
 }


### PR DESCRIPTION
Summary (<=10 lines):
- Add LocalAuthRepository + AuthController (Riverpod)
- Implement LoginPage with validation & loading
- Add route guard + auth-driven redirect
- Update main.dart to use router provider (M3)
- Fix default widget_test to boot at /login

Decision: LGTM / Needs changes
Notes: risks (redirect loop), follow-ups (sign-out button, Firebase Auth swap, CI)
