### PR TITLE
Feature/auth login and guard

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,6 +15,11 @@
 			"label": "flutter_test_retry",
 			"type": "shell",
 			"command": "flutter test"
+		},
+		{
+			"label": "flutter_run_analyze",
+			"type": "shell",
+			"command": "flutter --version; dart --version; flutter pub get; flutter analyze"
 		}
 	]
 }

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -13,14 +15,18 @@ final routerProvider = Provider<GoRouter>((ref) {
     final auth = ref.read(authControllerProvider);
     final loggedIn = auth.userId != null;
 
-    // go_router 現行版: matchedLocation / uri が使えます
-    final loc = state.matchedLocation; // e.g. "/login"
+    // e.g. "/login"
+    final loc = state.matchedLocation;
     final loggingIn = loc == '/login';
+    if (kDebugMode) debugPrint('[redirect] loc=$loc loggedIn=$loggedIn');
 
     if (!loggedIn && !loggingIn) return '/login';
     if (loggedIn && loggingIn) return '/dashboard';
     return null;
   }
+
+  // Stream of auth changes (from repository)
+  final authChanges = ref.read(authRepositoryProvider).authStateChanges();
 
   final router = GoRouter(
     // 未ログインは redirect で /login へ飛ぶ前提
@@ -40,9 +46,26 @@ final routerProvider = Provider<GoRouter>((ref) {
         },
       ),
     ],
+    // Auth 変更でルータを自動リフレッシュ
+    refreshListenable: RouterRefreshStream(authChanges),
   );
 
-  // Auth 状態変化で redirect を再評価
+  // 追加の保険（State変化で手動 refresh）
   ref.listen(authControllerProvider, (_, __) => router.refresh());
+
   return router;
 });
+
+/// Minimal Listenable that triggers GoRouter.refresh() on every stream event.
+/// (Fallback for environments where GoRouterRefreshStream isn't available.)
+class RouterRefreshStream extends ChangeNotifier {
+  late final StreamSubscription _sub;
+  RouterRefreshStream(Stream<dynamic> stream) {
+    _sub = stream.listen((_) => notifyListeners());
+  }
+  @override
+  void dispose() {
+    _sub.cancel();
+    super.dispose();
+  }
+}

--- a/lib/features/auth/controller/auth_controller.dart
+++ b/lib/features/auth/controller/auth_controller.dart
@@ -1,69 +1,63 @@
 import 'dart:async';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-
-import '../domain/auth_repository.dart';
 import '../data/local_auth_repository.dart';
+import '../domain/auth_repository.dart';
 
 class AuthState {
   final bool isLoading;
   final String? userId;
   final String? error;
-
   const AuthState({this.isLoading = false, this.userId, this.error});
 
-  AuthState copyWith({bool? isLoading, String? userId, String? error}) {
-    return AuthState(
-      isLoading: isLoading ?? this.isLoading,
-      userId: userId ?? this.userId,
-      error: error,
-    );
-  }
+  AuthState copyWith({bool? isLoading, String? userId, String? error}) =>
+      AuthState(
+        isLoading: isLoading ?? this.isLoading,
+        userId: userId,
+        error: error,
+      );
 }
 
 class AuthController extends StateNotifier<AuthState> {
-  AuthController(this._repo) : super(const AuthState()) {
-    _sub = _repo.authStateChanges().listen((uid) {
-      state = state.copyWith(userId: uid, isLoading: false, error: null);
+  final AuthRepository _repo;
+  late final StreamSubscription _sub;
+
+  AuthController(this._repo) : super(AuthState(userId: _repo.currentUserId)) {
+    _sub = _repo.authStateChanges().listen((id) {
+      state = state.copyWith(isLoading: false, userId: id, error: null);
     });
   }
 
-  final AuthRepository _repo;
-  StreamSubscription<String?>? _sub;
-
   Future<void> signIn(String email, String password) async {
-    state = state.copyWith(isLoading: true, error: null);
+    state = state.copyWith(isLoading: true, error: null, userId: state.userId);
     try {
-      final uid = await _repo.signIn(email: email, password: password);
-      state = state.copyWith(userId: uid, isLoading: false, error: null);
+      await _repo.signIn(email: email, password: password);
+      // 成功時は repo 側のストリームで userId が入る
     } catch (e) {
-      state = state.copyWith(isLoading: false, error: e.toString());
+      state = state.copyWith(
+        isLoading: false,
+        error: e.toString(),
+        userId: null,
+      );
     }
   }
 
   Future<void> signOut() async {
-    state = state.copyWith(isLoading: true, error: null);
     await _repo.signOut();
-    state = state.copyWith(isLoading: false);
+    // ★ 念のため即時に userId を null に（ストリームを待たない）
+    state = state.copyWith(isLoading: false, error: null, userId: null);
   }
 
   @override
   void dispose() {
-    _sub?.cancel();
+    _sub.cancel();
     super.dispose();
   }
 }
 
-// Providers
 final authRepositoryProvider = Provider<AuthRepository>((ref) {
-  final repo = LocalAuthRepository();
-  ref.onDispose(() => repo.dispose());
-  return repo;
+  return LocalAuthRepository();
 });
 
 final authControllerProvider = StateNotifierProvider<AuthController, AuthState>(
-  (ref) {
-    final repo = ref.watch(authRepositoryProvider);
-    return AuthController(repo);
-  },
+  (ref) => AuthController(ref.watch(authRepositoryProvider)),
 );

--- a/lib/features/auth/data/local_auth_repository.dart
+++ b/lib/features/auth/data/local_auth_repository.dart
@@ -1,47 +1,35 @@
 import 'dart:async';
+import '../domain/auth_repository.dart';
 
-import '../../auth/domain/auth_repository.dart';
-
-/// A local in-memory implementation of [AuthRepository].
 class LocalAuthRepository implements AuthRepository {
-  final _controller = StreamController<String?>.broadcast();
-  String? _currentUserId;
+  String? _current;
+  final _ctrl = StreamController<String?>.broadcast();
+
+  LocalAuthRepository();
 
   @override
-  String? get currentUserId => _currentUserId;
+  String? get currentUserId => _current;
+
+  @override
+  Stream<String?> authStateChanges() => _ctrl.stream;
 
   @override
   Future<String> signIn({
     required String email,
     required String password,
   }) async {
-    await Future<void>.delayed(const Duration(milliseconds: 400));
-
+    await Future<void>.delayed(const Duration(milliseconds: 300));
     if (!email.contains('@') || password.length < 6) {
       throw Exception('Invalid credentials');
     }
-
-    // Generate a simple user id from email.
-    _currentUserId = email;
-    _controller.add(_currentUserId);
-    return _currentUserId!;
+    _current = 'user_${email.hashCode}';
+    _ctrl.add(_current);
+    return _current!;
   }
 
   @override
   Future<void> signOut() async {
-    await Future<void>.delayed(const Duration(milliseconds: 100));
-    _currentUserId = null;
-    _controller.add(_currentUserId);
-  }
-
-  @override
-  Stream<String?> authStateChanges() async* {
-    // Emit initial state then subsequent changes.
-    yield _currentUserId;
-    yield* _controller.stream;
-  }
-
-  void dispose() {
-    _controller.close();
+    _current = null;
+    _ctrl.add(null); // ★ 確実に通知
   }
 }

--- a/lib/features/auth/presentation/login_page.dart
+++ b/lib/features/auth/presentation/login_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../auth/controller/auth_controller.dart';
+import 'package:go_router/go_router.dart';
 
 class LoginPage extends ConsumerStatefulWidget {
   const LoginPage({super.key});
@@ -82,9 +83,21 @@ class _LoginPageState extends ConsumerState<LoginPage> {
                           ? null
                           : () async {
                               if (!_formKey.currentState!.validate()) return;
+
+                              // 1) サインイン実行
                               await ref
                                   .read(authControllerProvider.notifier)
                                   .signIn(_emailCtrl.text.trim(), _pwCtrl.text);
+
+                              // 2) 成功時のみ履歴を置換して /dashboard へ
+                              if (!context.mounted) return;
+                              final userId = ref
+                                  .read(authControllerProvider)
+                                  .userId;
+                              if (userId != null) {
+                                // redirect による遷移と競合しません。/login が履歴に残らないように置換します。
+                                context.replace('/dashboard');
+                              }
                             },
                       child: state.isLoading
                           ? const SizedBox(

--- a/lib/features/dashboard/presentation/dashboard_page.dart
+++ b/lib/features/dashboard/presentation/dashboard_page.dart
@@ -1,12 +1,39 @@
+// lib/features/dashboard/presentation/dashboard_page.dart
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
-class DashboardPage extends StatelessWidget {
+// ← 相対パスを1つ短くする（../../）
+import '../../auth/controller/auth_controller.dart';
+import 'package:flutter/foundation.dart' show kDebugMode;
+
+class DashboardPage extends ConsumerWidget {
   const DashboardPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Dashboard')),
+      appBar: AppBar(
+        title: const Text('Dashboard'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.logout),
+            tooltip: 'Sign out',
+            onPressed: () async {
+              if (kDebugMode) debugPrint('[logout] pressed');
+
+              await ref.read(authControllerProvider.notifier).signOut();
+
+              if (kDebugMode) {
+                final uid = ref.read(authControllerProvider).userId;
+                debugPrint('[logout] userId after signOut = $uid');
+              }
+
+              if (context.mounted) context.go('/login');
+            },
+          ),
+        ],
+      ),
       body: const Center(child: Text('Dashboard')),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'app/router.dart';
 
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter_web_plugins/url_strategy.dart';
+
+void main() {
+  if (kIsWeb) {
+    // Remove '#' from web URLs
+    setUrlStrategy(PathUrlStrategy());
+  }
+  runApp(const ProviderScope(child: MyApp()));
+}
+
 // Wrap MaterialApp with ProviderScope & use GoRouter
 class MyApp extends ConsumerWidget {
   const MyApp({super.key});
@@ -19,5 +30,3 @@ class MyApp extends ConsumerWidget {
     );
   }
 }
-
-void main() => runApp(const ProviderScope(child: MyApp()));

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -84,7 +84,7 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_web_plugins:
-    dependency: transitive
+    dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,8 @@ dependencies:
   # ==== 主要パッケージ ====
   flutter_riverpod: ^2.6.1
   go_router: ^14.2.6
+  flutter_web_plugins:
+    sdk: flutter
   cupertino_icons: ^1.0.8
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
Summary:
- Ensure logout navigates to /login reliably
- Await signOut then context.go('/login')
- Router now auto-refreshes on auth changes (stream-based) + keeps manual refresh

Manual QA (web):
- Login -> Dashboard ✅
- Click "Sign out" -> redirected to /login ✅
- Attempt /dashboard when signed out -> stays on /login ✅
- Analyze & tests: green ✅

Notes:
- Logs guarded by kDebugMode (or removed before merge)
