### PR TITLE
Add auth flow tests and CI coverage pipeline

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -1,15 +1,17 @@
 name: Flutter CI
 
 on:
-  push:
-    branches: [ main, develop, feature/** ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ master, develop ]   # ← PRは必ずCI
+  push:
+    branches: [ master ]            # ← 直接pushは最小限
+    tags:
+      - 'v*.*.*'                    # ← リリースタグで回す
+  workflow_dispatch: {}       # ← 手動トリガー
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -19,17 +21,14 @@ jobs:
         with:
           channel: stable
 
-      - name: Install dependencies
-        run: flutter pub get
-
-      - name: Flutter analyze
-        run: flutter analyze
-
+      - run: flutter --version
+      - run: flutter pub get
+      - run: flutter analyze
       - name: Flutter tests with coverage
-        run: flutter test --coverage
+        run: flutter test --coverage -r expanded
 
-      - name: Upload coverage artifact
+      - name: Upload coverage
         uses: actions/upload-artifact@v4
         with:
           name: coverage
-          path: coverage/
+          path: coverage

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -1,0 +1,35 @@
+name: Flutter CI
+
+on:
+  push:
+    branches: [ main, develop, feature/** ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Flutter analyze
+        run: flutter analyze
+
+      - name: Flutter tests with coverage
+        run: flutter test --coverage
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ migrate_working_dir/
 .pub-cache/
 .pub/
 /build/
+coverage/
 
 # Symbolication related
 app.*.symbols

--- a/test/auth_controller_test.dart
+++ b/test/auth_controller_test.dart
@@ -1,0 +1,106 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:lms_app/features/auth/controller/auth_controller.dart';
+import 'package:lms_app/features/auth/domain/auth_repository.dart';
+
+class _TestAuthRepository implements AuthRepository {
+  _TestAuthRepository({this.currentUserId});
+
+  @override
+  String? currentUserId;
+
+  final _controller = StreamController<String?>.broadcast();
+
+  final List<String?> emittedUserIds = <String?>[];
+
+  bool shouldThrow = false;
+
+  @override
+  Stream<String?> authStateChanges() => _controller.stream;
+
+  @override
+  Future<String> signIn({required String email, required String password}) async {
+    if (shouldThrow) {
+      throw Exception('Invalid credentials');
+    }
+    currentUserId = 'user-123';
+    emittedUserIds.add(currentUserId);
+    _controller.add(currentUserId);
+    return currentUserId!;
+  }
+
+  @override
+  Future<void> signOut() async {
+    currentUserId = null;
+    emittedUserIds.add(null);
+    _controller.add(null);
+  }
+}
+
+void main() {
+  group('AuthController', () {
+    test('signIn should set userId and clear error on success', () async {
+      // Arrange
+      final repo = _TestAuthRepository();
+      final container = ProviderContainer(
+        overrides: [authRepositoryProvider.overrideWithValue(repo)],
+      );
+      addTearDown(container.dispose);
+      final controller = container.read(authControllerProvider.notifier);
+
+      // Act
+      await controller.signIn('test@example.com', 'password');
+      await Future<void>.delayed(Duration.zero);
+
+      // Assert
+      final state = container.read(authControllerProvider);
+      expect(state.userId, isNotNull);
+      expect(state.error, isNull);
+      expect(repo.emittedUserIds.last, isNotNull);
+    });
+
+    test('signIn should expose error and reset loading on failure', () async {
+      // Arrange
+      final repo = _TestAuthRepository()..shouldThrow = true;
+      final container = ProviderContainer(
+        overrides: [authRepositoryProvider.overrideWithValue(repo)],
+      );
+      addTearDown(container.dispose);
+      final controller = container.read(authControllerProvider.notifier);
+
+      // Act
+      await controller.signIn('invalid', '123');
+      await Future<void>.delayed(Duration.zero);
+
+      // Assert
+      final state = container.read(authControllerProvider);
+      expect(state.userId, isNull);
+      expect(state.isLoading, isFalse);
+      expect(state.error, contains('Invalid credentials'));
+    });
+
+    test('signOut should clear userId immediately and emit null', () async {
+      // Arrange
+      final repo = _TestAuthRepository();
+      final container = ProviderContainer(
+        overrides: [authRepositoryProvider.overrideWithValue(repo)],
+      );
+      addTearDown(container.dispose);
+      final controller = container.read(authControllerProvider.notifier);
+      await controller.signIn('test@example.com', 'password');
+      await Future<void>.delayed(Duration.zero);
+
+      // Act
+      await controller.signOut();
+      await Future<void>.delayed(Duration.zero);
+
+      // Assert
+      final state = container.read(authControllerProvider);
+      expect(state.userId, isNull);
+      expect(repo.emittedUserIds.contains(null), isTrue);
+    });
+  });
+}

--- a/test/auth_controller_test.dart
+++ b/test/auth_controller_test.dart
@@ -7,7 +7,7 @@ import 'package:lms_app/features/auth/controller/auth_controller.dart';
 import 'package:lms_app/features/auth/domain/auth_repository.dart';
 
 class _TestAuthRepository implements AuthRepository {
-  _TestAuthRepository({this.currentUserId});
+  _TestAuthRepository();
 
   @override
   String? currentUserId;
@@ -22,7 +22,10 @@ class _TestAuthRepository implements AuthRepository {
   Stream<String?> authStateChanges() => _controller.stream;
 
   @override
-  Future<String> signIn({required String email, required String password}) async {
+  Future<String> signIn({
+    required String email,
+    required String password,
+  }) async {
     if (shouldThrow) {
       throw Exception('Invalid credentials');
     }

--- a/test/login_page_test.dart
+++ b/test/login_page_test.dart
@@ -1,0 +1,116 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:lms_app/features/auth/controller/auth_controller.dart';
+import 'package:lms_app/features/auth/domain/auth_repository.dart';
+import 'package:lms_app/main.dart';
+import 'package:lms_app/features/auth/presentation/login_page.dart';
+
+class _TestAuthRepository implements AuthRepository {
+  _TestAuthRepository({this.currentUserId});
+
+  @override
+  String? currentUserId;
+
+  final _controller = StreamController<String?>.broadcast();
+
+  bool shouldThrow = false;
+
+  @override
+  Stream<String?> authStateChanges() => _controller.stream;
+
+  @override
+  Future<String> signIn({required String email, required String password}) async {
+    if (shouldThrow) {
+      throw Exception('Invalid credentials');
+    }
+    currentUserId = 'user-${email.hashCode}';
+    _controller.add(currentUserId);
+    return currentUserId!;
+  }
+
+  @override
+  Future<void> signOut() async {
+    currentUserId = null;
+    _controller.add(null);
+  }
+}
+
+Future<void> _pumpApp(WidgetTester tester, AuthRepository repository,
+    {Widget? child}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [authRepositoryProvider.overrideWithValue(repository)],
+      child: MaterialApp(
+        home: child ?? const LoginPage(),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('LoginPage', () {
+    testWidgets('should show validation errors when email/password invalid',
+        (tester) async {
+      // Arrange
+      final repo = _TestAuthRepository();
+      await _pumpApp(tester, repo);
+
+      // Act
+      await tester.tap(find.text('Sign in'));
+      await tester.pump();
+
+      // Assert
+      expect(find.text('Enter email'), findsOneWidget);
+      expect(find.text('Enter password'), findsOneWidget);
+
+      // Act
+      await tester.enterText(find.widgetWithText(TextFormField, 'Email'), 'abc');
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Password'),
+        '123',
+      );
+      await tester.tap(find.text('Sign in'));
+      await tester.pump();
+
+      // Assert
+      expect(find.text('Invalid email'), findsOneWidget);
+      expect(find.text('Min 6 characters'), findsOneWidget);
+    });
+
+    testWidgets('should call signIn and navigate to Dashboard on success',
+        (tester) async {
+      // Arrange
+      final repo = _TestAuthRepository();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [authRepositoryProvider.overrideWithValue(repo)],
+          child: const MyApp(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Assert initial screen
+      expect(find.text('Login'), findsOneWidget);
+
+      // Act
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Email'),
+        'test@example.com',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Password'),
+        '123456',
+      );
+      await tester.tap(find.text('Sign in'));
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(find.text('Dashboard'), findsWidgets);
+    });
+  });
+}

--- a/test/login_page_test.dart
+++ b/test/login_page_test.dart
@@ -10,7 +10,7 @@ import 'package:lms_app/main.dart';
 import 'package:lms_app/features/auth/presentation/login_page.dart';
 
 class _TestAuthRepository implements AuthRepository {
-  _TestAuthRepository({this.currentUserId});
+  _TestAuthRepository();
 
   @override
   String? currentUserId;
@@ -23,7 +23,10 @@ class _TestAuthRepository implements AuthRepository {
   Stream<String?> authStateChanges() => _controller.stream;
 
   @override
-  Future<String> signIn({required String email, required String password}) async {
+  Future<String> signIn({
+    required String email,
+    required String password,
+  }) async {
     if (shouldThrow) {
       throw Exception('Invalid credentials');
     }
@@ -39,14 +42,15 @@ class _TestAuthRepository implements AuthRepository {
   }
 }
 
-Future<void> _pumpApp(WidgetTester tester, AuthRepository repository,
-    {Widget? child}) async {
+Future<void> _pumpApp(
+  WidgetTester tester,
+  AuthRepository repository, {
+  Widget? child,
+}) async {
   await tester.pumpWidget(
     ProviderScope(
       overrides: [authRepositoryProvider.overrideWithValue(repository)],
-      child: MaterialApp(
-        home: child ?? const LoginPage(),
-      ),
+      child: MaterialApp(home: child ?? const LoginPage()),
     ),
   );
   await tester.pumpAndSettle();
@@ -54,8 +58,9 @@ Future<void> _pumpApp(WidgetTester tester, AuthRepository repository,
 
 void main() {
   group('LoginPage', () {
-    testWidgets('should show validation errors when email/password invalid',
-        (tester) async {
+    testWidgets('should show validation errors when email/password invalid', (
+      tester,
+    ) async {
       // Arrange
       final repo = _TestAuthRepository();
       await _pumpApp(tester, repo);
@@ -69,7 +74,10 @@ void main() {
       expect(find.text('Enter password'), findsOneWidget);
 
       // Act
-      await tester.enterText(find.widgetWithText(TextFormField, 'Email'), 'abc');
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Email'),
+        'abc',
+      );
       await tester.enterText(
         find.widgetWithText(TextFormField, 'Password'),
         '123',
@@ -82,8 +90,9 @@ void main() {
       expect(find.text('Min 6 characters'), findsOneWidget);
     });
 
-    testWidgets('should call signIn and navigate to Dashboard on success',
-        (tester) async {
+    testWidgets('should call signIn and navigate to Dashboard on success', (
+      tester,
+    ) async {
       // Arrange
       final repo = _TestAuthRepository();
       await tester.pumpWidget(

--- a/test/logout_flow_test.dart
+++ b/test/logout_flow_test.dart
@@ -1,0 +1,58 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:lms_app/features/auth/controller/auth_controller.dart';
+import 'package:lms_app/features/auth/domain/auth_repository.dart';
+import 'package:lms_app/main.dart';
+
+class _TestAuthRepository implements AuthRepository {
+  _TestAuthRepository({this.currentUserId});
+
+  @override
+  String? currentUserId;
+
+  final _controller = StreamController<String?>.broadcast();
+
+  @override
+  Stream<String?> authStateChanges() => _controller.stream;
+
+  @override
+  Future<String> signIn({required String email, required String password}) async {
+    currentUserId = 'user-123';
+    _controller.add(currentUserId);
+    return currentUserId!;
+  }
+
+  @override
+  Future<void> signOut() async {
+    currentUserId = null;
+    _controller.add(null);
+  }
+}
+
+void main() {
+  testWidgets('logout from Dashboard should navigate back to Login', (tester) async {
+    // Arrange
+    final repo = _TestAuthRepository(currentUserId: 'user-123');
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [authRepositoryProvider.overrideWithValue(repo)],
+        child: const MyApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Confirm dashboard visible
+    expect(find.text('Dashboard'), findsWidgets);
+
+    // Act
+    await tester.tap(find.byTooltip('Sign out'));
+    await tester.pumpAndSettle();
+
+    // Assert
+    expect(find.text('Login'), findsOneWidget);
+  });
+}

--- a/test/router_guard_test.dart
+++ b/test/router_guard_test.dart
@@ -1,0 +1,80 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:lms_app/features/auth/controller/auth_controller.dart';
+import 'package:lms_app/features/auth/domain/auth_repository.dart';
+import 'package:lms_app/main.dart';
+
+class _TestAuthRepository implements AuthRepository {
+  _TestAuthRepository({this.currentUserId});
+
+  @override
+  String? currentUserId;
+
+  final _controller = StreamController<String?>.broadcast();
+
+  @override
+  Stream<String?> authStateChanges() => _controller.stream;
+
+  @override
+  Future<String> signIn({required String email, required String password}) async {
+    currentUserId = 'user-123';
+    _controller.add(currentUserId);
+    return currentUserId!;
+  }
+
+  @override
+  Future<void> signOut() async {
+    currentUserId = null;
+    _controller.add(null);
+  }
+}
+
+void main() {
+  group('Router redirect guard', () {
+    testWidgets('should redirect unauthenticated users from /dashboard to /login',
+        (tester) async {
+      // Arrange
+      final repo = _TestAuthRepository(currentUserId: null);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [authRepositoryProvider.overrideWithValue(repo)],
+          child: const MyApp(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(find.text('Login'), findsOneWidget);
+    });
+
+    testWidgets('should redirect authenticated users away from /login',
+        (tester) async {
+      // Arrange
+      final repo = _TestAuthRepository(currentUserId: 'user-123');
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [authRepositoryProvider.overrideWithValue(repo)],
+          child: const MyApp(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Confirm dashboard shown initially
+      expect(find.text('Dashboard'), findsWidgets);
+
+      // Act
+      final BuildContext context = tester.element(find.text('Dashboard').first);
+      GoRouter.of(context).go('/login');
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(find.text('Dashboard'), findsWidgets);
+    });
+  });
+}

--- a/test/router_guard_test.dart
+++ b/test/router_guard_test.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import 'package:lms_app/features/auth/controller/auth_controller.dart';
 import 'package:lms_app/features/auth/domain/auth_repository.dart';
 import 'package:lms_app/main.dart';
+import 'package:flutter/material.dart';
 
 class _TestAuthRepository implements AuthRepository {
   _TestAuthRepository({this.currentUserId});
@@ -20,7 +21,10 @@ class _TestAuthRepository implements AuthRepository {
   Stream<String?> authStateChanges() => _controller.stream;
 
   @override
-  Future<String> signIn({required String email, required String password}) async {
+  Future<String> signIn({
+    required String email,
+    required String password,
+  }) async {
     currentUserId = 'user-123';
     _controller.add(currentUserId);
     return currentUserId!;
@@ -35,25 +39,28 @@ class _TestAuthRepository implements AuthRepository {
 
 void main() {
   group('Router redirect guard', () {
-    testWidgets('should redirect unauthenticated users from /dashboard to /login',
-        (tester) async {
-      // Arrange
-      final repo = _TestAuthRepository(currentUserId: null);
+    testWidgets(
+      'should redirect unauthenticated users from /dashboard to /login',
+      (tester) async {
+        // Arrange
+        final repo = _TestAuthRepository(currentUserId: null);
 
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [authRepositoryProvider.overrideWithValue(repo)],
-          child: const MyApp(),
-        ),
-      );
-      await tester.pumpAndSettle();
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [authRepositoryProvider.overrideWithValue(repo)],
+            child: const MyApp(),
+          ),
+        );
+        await tester.pumpAndSettle();
 
-      // Assert
-      expect(find.text('Login'), findsOneWidget);
-    });
+        // Assert
+        expect(find.text('Login'), findsOneWidget);
+      },
+    );
 
-    testWidgets('should redirect authenticated users away from /login',
-        (tester) async {
+    testWidgets('should redirect authenticated users away from /login', (
+      tester,
+    ) async {
       // Arrange
       final repo = _TestAuthRepository(currentUserId: 'user-123');
 


### PR DESCRIPTION
## Summary
- add Riverpod-based unit tests for the auth controller covering sign-in and sign-out flows
- create widget tests for login validation, router guards, and logout navigation to ensure UI redirects
- configure GitHub Actions workflow to run flutter analyze and flutter test with coverage artifact

## Testing
- flutter analyze *(fails locally: flutter not installed in container)*
- flutter test --coverage *(fails locally: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e8050428833085fdcc0ae0174289