### PR TITLE
test: add dashboard and course logout widget coverage

### DIFF
--- a/test/course_page_logout_test.dart
+++ b/test/course_page_logout_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:lms_app/features/auth/controller/auth_controller.dart';
+
+import 'helpers/pump_app.dart';
+
+void main() {
+  testWidgets('Course page logout routes back to login', (tester) async {
+    final authRepo = TestAuthRepository(currentUserId: 'user-123');
+    addTearDown(authRepo.dispose);
+
+    await pumpAppWithRouter(
+      tester,
+      overrides: [authRepositoryProvider.overrideWithValue(authRepo)],
+      initialLocation: '/course/intro',
+    );
+
+    expect(find.widgetWithText(AppBar, 'Course intro'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Sign out'));
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(AppBar, 'Login'), findsOneWidget);
+  });
+}

--- a/test/dashboard_page_test.dart
+++ b/test/dashboard_page_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:lms_app/features/auth/controller/auth_controller.dart';
+
+import 'helpers/pump_app.dart';
+
+void main() {
+  testWidgets(
+    'Dashboard renders expected cards and navigates to intro course',
+    (tester) async {
+      final authRepo = TestAuthRepository(currentUserId: 'user-123');
+      addTearDown(authRepo.dispose);
+
+      await pumpAppWithRouter(
+        tester,
+        overrides: [authRepositoryProvider.overrideWithValue(authRepo)],
+        initialLocation: '/dashboard',
+      );
+
+      expect(find.text("Today's Tasks"), findsOneWidget);
+      expect(find.text('Progress by Course'), findsOneWidget);
+      expect(find.text('Continue Learning'), findsOneWidget);
+
+      await tester.tap(find.text('Resume "Intro Course"'));
+      await tester.pumpAndSettle();
+
+      expect(find.widgetWithText(AppBar, 'Course intro'), findsOneWidget);
+    },
+  );
+}

--- a/test/helpers/pump_app.dart
+++ b/test/helpers/pump_app.dart
@@ -1,0 +1,69 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:lms_app/app/router.dart';
+import 'package:lms_app/features/auth/controller/auth_controller.dart';
+import 'package:lms_app/features/auth/domain/auth_repository.dart';
+import 'package:lms_app/main.dart';
+
+class TestAuthRepository implements AuthRepository {
+  TestAuthRepository({String? currentUserId}) : _currentUserId = currentUserId;
+
+  String? _currentUserId;
+  late final StreamController<String?> _controller =
+      StreamController<String?>.broadcast(
+    onListen: () => _controller.add(_currentUserId),
+  );
+
+  @override
+  String? get currentUserId => _currentUserId;
+
+  @override
+  Stream<String?> authStateChanges() => _controller.stream;
+
+  @override
+  Future<String> signIn({
+    required String email,
+    required String password,
+  }) async {
+    _currentUserId = 'user-123';
+    _controller.add(_currentUserId);
+    return _currentUserId!;
+  }
+
+  @override
+  Future<void> signOut() async {
+    _currentUserId = null;
+    _controller.add(null);
+  }
+
+  void dispose() {
+    _controller.close();
+  }
+}
+
+Future<void> pumpAppWithRouter(
+  WidgetTester tester, {
+  List<Override> overrides = const [],
+  String? initialLocation,
+}) async {
+  final container = ProviderContainer(overrides: overrides);
+  addTearDown(container.dispose);
+
+  final router = container.read(routerProvider);
+  if (initialLocation != null) {
+    router.go(initialLocation);
+  }
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: const MyApp(),
+    ),
+  );
+
+  await tester.pump();
+  await tester.pumpAndSettle();
+}


### PR DESCRIPTION
## Summary
- add a reusable pumpAppWithRouter test helper with an injectable auth repository
- cover the dashboard cards and intro course navigation
- verify course page logout returns to the login screen

## Testing
- flutter analyze *(fails locally: Flutter SDK not installed in container)*
- flutter test --coverage *(fails locally: Flutter SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddebb81df88330b4d14ebd78e5c0e9